### PR TITLE
Add RedisClient option to BrokerConfig to use already initialized client

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -45,7 +45,7 @@ func newBroker(ctx context.Context, cfg BrokerConfig, logger logging.Logger) Bro
 
 	switch cfg.Type {
 	default:
-		broker = newRedisBroker(ctx, cfg.Redis, logger)
+		broker = newRedisBroker(ctx, cfg, logger)
 	}
 
 	return broker

--- a/config.go
+++ b/config.go
@@ -27,8 +27,9 @@ type QueueConfig struct {
 
 // BrokerConfig contains the broker configuration.
 type BrokerConfig struct {
-	Type  string
-	Redis RedisConfig
+	Type        string
+	Redis       RedisConfig
+	RedisClient *redis.Client
 }
 
 // Config contains the main configuration to initialize Bokchoy.


### PR DESCRIPTION
Adding RedisClient option to BrokerConfig so we can use an already initialized client.

Actually, we have a central place in our app where we initialize redis client and we don't want to init another one. It would be great if we can re-use the existing client. Also the current code for redis.NewClient(), NewFailoverClient() etc. does not include all the redis options, e.g. TLSConfig, OnConnect.