### PR TITLE
Remove redisClient in favour of UniversalClient

### DIFF
--- a/broker_redis.go
+++ b/broker_redis.go
@@ -14,14 +14,10 @@ import (
 	"github.com/pkg/errors"
 )
 
-type redisClient interface {
-	redis.UniversalClient
-}
-
 // RedisBroker is the redis broker.
 type RedisBroker struct {
 	ClientType string
-	Client     redisClient
+	Client     redis.UniversalClient
 	Prefix     string
 	Logger     logging.Logger
 	scripts    map[string]string
@@ -75,7 +71,7 @@ return cjson.encode(data)`,
 
 // newRedisBroker initializes a new redis client.
 func newRedisBroker(cfg RedisConfig, logger logging.Logger) *RedisBroker {
-	var clt redisClient
+	var clt redis.UniversalClient
 
 	switch cfg.Type {
 	case redisTypeSentinel:
@@ -132,7 +128,7 @@ func newRedisBroker(cfg RedisConfig, logger logging.Logger) *RedisBroker {
 }
 
 // NewRedisBroker initializes a new redis broker instance.
-func NewRedisBroker(clt redisClient, clientType string, prefix string, logger logging.Logger) *RedisBroker {
+func NewRedisBroker(clt redis.UniversalClient, clientType string, prefix string, logger logging.Logger) *RedisBroker {
 	return &RedisBroker{
 		ClientType: clientType,
 		Client:     clt,

--- a/examples/custom-broker/main.go
+++ b/examples/custom-broker/main.go
@@ -20,13 +20,12 @@ func main() {
 	clt := redis.NewClient(&redis.Options{
 		Addr: "localhost:6379",
 	})
+	
+	// define a new Redis broker with the 'tasks' prefix
+	bkr := bokchoy.NewRedisBroker(clt, "client", "tasks", logger)
 
 	// define the main engine which will manage queues
-	engine, err := bokchoy.New(ctx, bokchoy.Config{}, bokchoy.WithBroker(&bokchoy.RedisBroker{
-		Client:     clt,
-		ClientType: "client",
-		Logger:     logger,
-	}))
+	engine, err := bokchoy.New(ctx, bokchoy.Config{}, bokchoy.WithBroker(bkr))
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Remove our interface `redisClient` and swap it for goredis' `redis.UniversalClient` interface. This fixes the inability to provide custom brokers with goredis v7.

Couldn't see any reason as to why redisClient was being used. This allows the passing of a redis client as a custom broker, and updates the custom broker example.

If possible, would we be able to get a new release too? That way the redis v7 and these changes are easy to use :)