### PR TITLE
Add bokchoy.NewDefault function for the most common scenario.

### DIFF
--- a/bokchoy.go
+++ b/bokchoy.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/go-redis/redis/v7"
 	"github.com/thoas/bokchoy/logging"
 	"github.com/thoas/go-funk"
 
@@ -92,6 +93,27 @@ func New(ctx context.Context, cfg Config, options ...Option) (*Bokchoy, error) {
 	}
 
 	return bok, nil
+}
+
+// NewDefault initializes a new Bokchoy instance for the most common scenario.
+func NewDefault(ctx context.Context, redisURL string) (*Bokchoy, error) {
+	opt, err := redis.ParseURL(redisURL)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to parse redis url")
+	}
+	return New(ctx, Config{
+		Broker: BrokerConfig{
+			Type: "redis",
+			Redis: RedisConfig{
+				Type: "client",
+				Client: RedisClientConfig{
+					Addr:     opt.Addr,
+					Password: opt.Password,
+					DB:       opt.DB,
+				},
+			},
+		},
+	})
 }
 
 // Use append a new middleware to the system.


### PR DESCRIPTION
Redis is the primary broker used in bokchoy so it makes sense to simplify the standard
use case. Additionally the `redis.ParseURL` usage allows use with URLs like:

`redis://:password@host:port/db`

Currently this URL isn't possible without the end user manually parsing the URL. This URL
is standard for hosts such as Heroku.

I don't really care about the name `NewDefault` or `NewRedisDefault` or something different all together. But I think the idea is solid.

Additionally you could do something like the following instead of explicitly setting the `RedisClientConfig` fields, but I wanted it to be simple and clear what was happening.

```
Redis: RedisConfig{
    Type:   "client",
    Client: RedisClientConfig(*opt),
},
```