### PR TITLE
prevent OnCompleteFunc called before last retry

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -136,6 +136,8 @@ func (c *consumer) handleError(ctx context.Context, task *Task, err error) error
 	if task.MaxRetries == 0 {
 		c.logger.Debug(ctx, "Task marked as failed: no retry", logging.Object("task", task))
 
+		task.MaxRetries -= 1
+
 		err = c.queue.Save(ctx, task)
 		if err != nil {
 			return errors.Wrapf(err, "unable to handle error %s", task)

--- a/task.go
+++ b/task.go
@@ -358,7 +358,7 @@ func (t *Task) Finished() bool {
 		return true
 	}
 
-	if (t.OldStatus == taskStatusFailed || t.Status == taskStatusFailed) && t.MaxRetries == 0 {
+	if (t.OldStatus == taskStatusFailed || t.Status == taskStatusFailed) && t.MaxRetries < 0 {
 		return true
 	}
 


### PR DESCRIPTION
Hi @thoas,

First of all, thank you for creating this useful library for task scheduling.

I noticed that the `queue.OnCompleteFunc` is triggered before the last retry takes place.  After checking the source code, I think the changes in this pull request will prevent it to happen.

Cheers, Hong